### PR TITLE
close body response to fix resource leak

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,6 +103,7 @@ func main() {
 			time.Sleep(checkIntervalDuration)
 			continue
 		}
+		response.Body.Close()
 
 		switch response.StatusCode {
 		case 200:


### PR DESCRIPTION
If vault-init runs for a while (say 12 hours with a 30 sec. check-interval) Vault gets unresponsive because vault-init doesn't close connections to Vault so no other clients can connect anymore. It can be observed with `netstat -na | grep 8200`. Established connections constantly raise with every vault-init check. This PR fixes the issue.