### PR TITLE
add func name when response is not 200

### DIFF
--- a/main.go
+++ b/main.go
@@ -156,7 +156,7 @@ func initialize() {
 	}
 
 	if response.StatusCode != 200 {
-		log.Printf("Non 200 status code: %s", response.StatusCode)
+		log.Printf("initialize(): Non 200 status code: %s", response.StatusCode)
 		return
 	}
 
@@ -308,7 +308,7 @@ func unseal() {
 		}
 
 		if response.StatusCode != 200 {
-			log.Printf("Non 200 status code: %s", response.StatusCode)
+			log.Printf("unseal(): Non 200 status code: %s", response.StatusCode)
 			break
 		}
 


### PR DESCRIPTION
I had non-200 responses in the wild and wanted to know which function they were coming from. (It turned out that I had gotten a setup step wrong.)