### PR TITLE
fix: close http responses

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ func main() {
 	}
 
 	for {
-		response, err := httpClient.Get("https://127.0.0.1:8200/v1/sys/health")
+		response, err := httpClient.Head("https://127.0.0.1:8200/v1/sys/health")
 		if err != nil {
 			log.Println(err)
 			time.Sleep(checkIntervalDuration)
@@ -154,6 +154,7 @@ func initialize() {
 		log.Println(err)
 		return
 	}
+	defer response.Body.Close()
 
 	if response.StatusCode != 200 {
 		log.Printf("Non 200 status code: %s", response.StatusCode)
@@ -317,6 +318,7 @@ func unseal() {
 			log.Println(err)
 			break
 		}
+		defer response.Body.Close()
 
 		var unsealResponse UnsealResponse
 		if err := json.Unmarshal(unsealRequestResponseBody, &unsealResponse); err != nil {


### PR DESCRIPTION
fix case were unclosed response bodies causes vault-init to fail like so:
vault-2 vault-init 2018/06/01 18:22:48 Get https://127.0.0.1:8200/v1/sys/health: dial tcp 127.0.0.1:8200: connect: cannot assign requested address
vault-1 vault-init 2018/06/01 18:22:42 Get https://127.0.0.1:8200/v1/sys/health: dial tcp 127.0.0.1:8200: connect: cannot assign requested address
vault-0 vault-init 2018/06/01 18:22:46 Get https://127.0.0.1:8200/v1/sys/health: dial tcp 127.0.0.1:8200: connect: cannot assign requested address

use HTTP HEAD instead of GET where we don't read a body (is supported by vault)

I'm still learning golang, any feedback appreciated.