### PR TITLE
Allow only unsealing once

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The vault-init service supports the following environment variables for configur
 * `CHECK_INTERVAL` - The time in seconds between Vault health checks. (300)
 * `GCS_BUCKET_NAME` - The Google Cloud Storage Bucket where the vault master key and root token is stored. 
 * `KMS_KEY_ID` - The Google Cloud KMS key ID used to encrypt and decrypt the vault master key and root token.
+* `VAULT_ADDR` - the address of the Vault server to unseal. Defaults to `https://127.0.0.1:8200`.
+* `UNSEAL_ONCE` - only perform the init/unseal operation once. This is useful if you plan to seal the Vault manually. Note that this is once _per instance_ and can make Vault unable to service requests if it becomes sealed.
 
 ### Example Values
 

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ var (
 	httpClient    http.Client
 	kmsKeyId      string
 	storageClient *storage.Client
+	once          bool
 )
 
 // InitRequest holds a Vault init request.
@@ -89,6 +90,11 @@ func main() {
 		log.Fatal("KMS_KEY_ID must be set and not empty")
 	}
 
+	onceStr := os.Getenv("UNSEAL_ONCE")
+	if onceStr != "" {
+		once, _ = strconv.ParseBool(onceStr)
+	}
+
 	ctx := context.Background()
 	storageClient, err = storage.NewClient(ctx)
 	if err != nil {
@@ -130,6 +136,11 @@ func main() {
 			unseal()
 		default:
 			log.Printf("Vault is in an unknown state. Status code: %d", response.StatusCode)
+		}
+
+		if once {
+			log.Printf("Once mode enabled, exiting...")
+			os.Exit(0)
 		}
 
 		log.Printf("Next check in %s", checkIntervalDuration)


### PR DESCRIPTION
Right now, a manual sealing of the Vault will result in the auto-init unsealer immediately unsealing it again. This adds a new configuration option that makes the auto-init unsealer stop after the first success.

This still maintains HA in the event that Kubernetes moves the pod for rescheduling (since it'll spawn a new container), but solves the problem where the Vault server is sealed manually by an operator in response to a security incident.

/cc @kelseyhightower 